### PR TITLE
COM3D2_5 3.41 texture2d loadimage fix

### DIFF
--- a/COM3D2.i18nEx.Core/CompatTexture2DExtensions.cs
+++ b/COM3D2.i18nEx.Core/CompatTexture2DExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using UnityEngine;
+
+namespace COM3D2.i18nEx.Core
+{
+    static class CompatTexture2DExtensions
+    {
+        static MethodInfo ImageConversionLoadImage;
+        static MethodInfo Texture2DLoadImage;
+
+        static CompatTexture2DExtensions()
+        {
+            Texture2DLoadImage = typeof(Texture2D).GetMethod("LoadImage", new Type[] { typeof(byte[]) });
+
+            if (Texture2DLoadImage == null)
+            {
+               var imageConversionModule = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "UnityEngine.ImageConversionModule");
+                if (imageConversionModule == null)
+                {
+                    throw new Exception("Cannot find UnityEngine.ImageConversionModule assembly");
+                }
+
+                var imageConversionType = imageConversionModule.GetType("UnityEngine.ImageConversion");
+                if (imageConversionType == null)
+                {
+                    throw new Exception("Cannot find UnityEngine.ImageConversion type");
+                }
+
+                ImageConversionLoadImage = imageConversionType.GetMethod("LoadImage", new Type[] { typeof(Texture2D), typeof(byte[]), typeof(bool) });
+                if (imageConversionType != null)
+                {
+                    ImageConversionLoadImage = imageConversionType.GetMethod("LoadImage", new Type[] { typeof(Texture2D), typeof(byte[]), typeof(bool) });
+                }
+            }
+        }
+
+        public static bool LoadImageCompat(this Texture2D texture, byte[] data)
+        {
+            if (ImageConversionLoadImage != null)
+            {
+                return (bool)ImageConversionLoadImage.Invoke(null, new object[] { texture, data, false });
+            }
+            else
+            {
+                return (bool)Texture2DLoadImage.Invoke(texture, new object[] { data });
+            }
+        }
+    }
+}

--- a/COM3D2.i18nEx.Core/Hooks/ScriptTranslationHooks.cs
+++ b/COM3D2.i18nEx.Core/Hooks/ScriptTranslationHooks.cs
@@ -15,7 +15,7 @@ namespace COM3D2.i18nEx.Core.Hooks
         private static string tlSeparator;
 
         private static string TlSeparator =>
-            tlSeparator ??= LocalizationManager.ScriptTranslationMark
+            tlSeparator ??= CompatLocalizationManager.ScriptTranslationMark
                                                .FirstOrDefault(kv => kv.Value == Product.subTitleScenarioLanguage).Key;
 
         public static void Initialize()

--- a/COM3D2.i18nEx.Core/Hooks/TextureReplaceHooks.cs
+++ b/COM3D2.i18nEx.Core/Hooks/TextureReplaceHooks.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using COM3D2.i18nEx.Core.Util;
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.UI;

--- a/COM3D2.i18nEx.Core/Hooks/TextureReplaceHooks.cs
+++ b/COM3D2.i18nEx.Core/Hooks/TextureReplaceHooks.cs
@@ -128,8 +128,8 @@ namespace COM3D2.i18nEx.Core.Hooks
 
             if (tex is Texture2D tex2d)
             {
-                tex2d.LoadImage(EmptyBytes);
-                tex2d.LoadImage(newData);
+                tex2d.LoadImageCompat(EmptyBytes);
+                tex2d.LoadImageCompat(newData);
                 tex2d.name = $"i18n_{tex2d}";
             }
             else
@@ -169,8 +169,8 @@ namespace COM3D2.i18nEx.Core.Hooks
 
             if (tex is Texture2D tex2d)
             {
-                tex2d.LoadImage(EmptyBytes);
-                tex2d.LoadImage(newData);
+                tex2d.LoadImageCompat(EmptyBytes);
+                tex2d.LoadImageCompat(newData);
                 tex2d.name = $"i18n_{tex2d}";
             }
             else
@@ -207,8 +207,8 @@ namespace COM3D2.i18nEx.Core.Hooks
             if (Configuration.TextureReplacement.VerboseLogging.Value)
                 Core.Logger.LogInfo($"Replacing {value?.texture?.name}");
 
-            value.texture.LoadImage(EmptyBytes);
-            value.texture.LoadImage(newData);
+            value.texture.LoadImageCompat(EmptyBytes);
+            value.texture.LoadImageCompat(newData);
             value.texture.name = $"i18n_{value.texture.name}";
         }
 

--- a/COM3D2.i18nEx.Core/Util/CompatLocalizationManager.cs
+++ b/COM3D2.i18nEx.Core/Util/CompatLocalizationManager.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Scourt.Loc;
+using System.Reflection;
+
+
+
+namespace COM3D2.i18nEx.Core.Util
+{
+    internal class CompatLocalizationManager
+    {
+        public static readonly IEnumerable<KeyValuePair<string, Product.Language>> ScriptTranslationMark;
+
+        static CompatLocalizationManager()
+        {
+            // LocalizationManager.ScriptTranslationMark is a static field of type IReadOnlyDictionary (3.41+) or Dictionary (2.x) depending on version of the game
+            // obtain a reference via reflection as an IEnumerable<KeyValuePair<string,Product.Language>> so we can work with both cases
+
+            var scriptTranslationMarkField = typeof(LocalizationManager).GetField("ScriptTranslationMark", BindingFlags.Public | BindingFlags.Static);
+            if (scriptTranslationMarkField == null)
+            {
+                throw new Exception("Cannot find LocalizationManager.ScriptTranslationMark field");
+            }
+
+            ScriptTranslationMark = scriptTranslationMarkField.GetValue(null) as IEnumerable<KeyValuePair<string, Product.Language>>;
+        }
+    }
+}

--- a/COM3D2.i18nEx.Core/Util/CompatTexture2DExtensions.cs
+++ b/COM3D2.i18nEx.Core/Util/CompatTexture2DExtensions.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Text;
 using UnityEngine;
 
-namespace COM3D2.i18nEx.Core
+namespace COM3D2.i18nEx.Core.Util
 {
     static class CompatTexture2DExtensions
     {
@@ -18,7 +18,7 @@ namespace COM3D2.i18nEx.Core
 
             if (Texture2DLoadImage == null)
             {
-               var imageConversionModule = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "UnityEngine.ImageConversionModule");
+                var imageConversionModule = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "UnityEngine.ImageConversionModule");
                 if (imageConversionModule == null)
                 {
                     throw new Exception("Cannot find UnityEngine.ImageConversionModule assembly");


### PR DESCRIPTION
This should fix the LoadImage errors for COM3D2_5 3.41. Should still be binary compatible with 2.x